### PR TITLE
Cache directory lookups, periodically refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,14 @@ package:
 
 To help me personally, my next steps are:
 
-- Modify sudorolebindings to use new controller Add interface
-- Review small packages, consolidate where necessary, add unit tests
-- Document installation procedure
-- Investigate installing webhooks: can we test admission webhooks with the
-  integration test suite?
+- [x] Cache directory lookups
+- [ ] Support pagination for Google directory lookups
+- [ ] Restructure DirectoryRoleBinding to use Spec
+- [ ] Modify sudorolebindings to use new controller Add interface
+- [ ] Review small packages, consolidate where necessary, add unit tests
+- [ ] Document installation procedure
+- [ ] Investigate installing webhooks: can we test admission webhooks with the
+      integration test suite?
 
 ## Getting Started
 

--- a/cmd/manager/manager.go
+++ b/cmd/manager/manager.go
@@ -29,10 +29,10 @@ import (
 )
 
 var (
-	app             = kingpin.New("manager", "Manages lawrjone.xyz operators 😷").Version(Version)
-	subject         = app.Flag("subject", "Service Subject account").Default("robot-admin@gocardless.com").String()
-	refreshInterval = app.Flag("refresh-interval", "Period to refresh our listeners").Default("10s").Duration()
-	threads         = app.Flag("threads", "Number of threads for the operator").Default("2").Int()
+	app              = kingpin.New("manager", "Manages lawrjone.xyz operators 😷").Version(Version)
+	subject          = app.Flag("subject", "Service Subject account").Default("robot-admin@gocardless.com").String()
+	directoryRefresh = app.Flag("directory-refresh", "Refresh interval for directory operations").Default("5m").Duration()
+	threads          = app.Flag("threads", "Number of threads for the operator").Default("2").Int()
 
 	logger = kitlog.NewLogfmtLogger(os.Stderr)
 
@@ -77,7 +77,7 @@ func main() {
 
 	// DirectoryRoleBinding controller
 	directory := directoryrolebinding.NewGoogleDirectory(directoryService.Members)
-	if _, err = directoryrolebinding.Add(ctx, mgr, logger, directory); err != nil {
+	if _, err = directoryrolebinding.Add(ctx, mgr, logger, directory, *directoryRefresh); err != nil {
 		app.Fatalf(err.Error())
 	}
 

--- a/pkg/controllers/directoryrolebinding/integration/controller_test.go
+++ b/pkg/controllers/directoryrolebinding/integration/controller_test.go
@@ -64,20 +64,21 @@ var _ = Describe("DirectoryRoleBindingReconciler", func() {
 		teardown  func()
 		mgr       manager.Manager
 		calls     chan integration.ReconcileCall
-		directory map[string][]string
+		groups    map[string][]string
 	)
 
 	BeforeEach(func() {
 		ctx, cancel = context.WithTimeout(context.Background(), time.Minute)
 		namespace, teardown = integration.CreateNamespace(clientset)
 		mgr = integration.StartTestManager(ctx, cfg)
-		directory = map[string][]string{}
+		groups = map[string][]string{}
 
 		_, err := directoryrolebinding.Add(
 			ctx,
 			mgr,
 			kitlog.NewLogfmtLogger(GinkgoWriter),
-			directoryrolebinding.NewFakeDirectory(directory),
+			directoryrolebinding.NewFakeDirectory(groups),
+			time.Duration(0), // don't test our caching/re-enqueue here
 			func(opt *controller.Options) {
 				opt.Reconciler, calls = integration.CaptureReconcile(
 					opt.Reconciler,
@@ -99,10 +100,10 @@ var _ = Describe("DirectoryRoleBindingReconciler", func() {
 
 	Context("With all@ and platform@", func() {
 		BeforeEach(func() {
-			directory["all@gocardless.com"] = []string{
+			groups["all@gocardless.com"] = []string{
 				"lawrence@gocardless.com",
 			}
-			directory["platform@gocardless.com"] = []string{
+			groups["platform@gocardless.com"] = []string{
 				"lawrence@gocardless.com",
 				"chris@gocardless.com",
 			}


### PR DESCRIPTION
The Google directory lookup APIs are quite expensive, and most users
will want to avoid hitting rate limits in normal operation. Without
caching, the number of API calls will scale linearly with the number of
groups used in all directory role bindings in the cluster: this is
likely to hit limits fast.

This change adds a cached directory role binding so that we cache
results on the group key. Membership changes are infrequent, so we
assume a default cache TTL as 5m. Using the cache means the number of
API requests made to the directory service will scale lineraly with the
number of **distinct** groups used across all directory role bindings in
the cluster, which could be a significant improvement.

Finally, we add a refresh parameter that causes the controller to
periodically reschedule reconciles, ensuring that changes to the group
membership in Google will be propagated to the role bindings in the
cluster.