### PR TITLE
Don't use default service account

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -39,6 +39,11 @@ rules:
     verbs:
       - "*"
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: manager
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -49,7 +54,7 @@ roleRef:
   name: manager-role
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: manager
     namespace: system
 ---
 apiVersion: apps/v1
@@ -72,6 +77,7 @@ spec:
         app: manager
         group: lawrjone.xyz
     spec:
+      serviceAccountName: manager
       terminationGracePeriodSeconds: 10
       volumes:
         - name: google-application-credentials


### PR DESCRIPTION
It's best to be explicit when running a pod that it should be targetting
a service account, rather than set default privileges within a
namespace.